### PR TITLE
Treat comma after P specifier as optional

### DIFF
--- a/src/fsource/lexer.py
+++ b/src/fsource/lexer.py
@@ -148,7 +148,8 @@ def get_lexer_regex():
                          | A      \d*
                          | X
                          )(?=\s*[:/,)])
-                    |(?:-?\d+P)(?=\s*,?[\d:DEFG])"""
+                  | (?:\d+P)      (?=\s*,?)"""  # Matches scale factor P
+                                                # followed by optional comma
     fortran_token = re.compile(r"""(?ix)
           {skipws}(?:
             ({word})                            #  1 word

--- a/src/fsource/lexer.py
+++ b/src/fsource/lexer.py
@@ -146,8 +146,9 @@ def get_lexer_regex():
                          | G      \d+ (?: \.\d+  (?: E\d+)?)?
                          | L      \d+
                          | A      \d*
-                         | [XP]
-                         )(?=\s*[:/,)])"""
+                         | X
+                         )(?=\s*[:/,)])
+                    |(?:-?\d+P)(?=\s*,?[\d:DEFG])"""
     fortran_token = re.compile(r"""(?ix)
           {skipws}(?:
             ({word})                            #  1 word


### PR DESCRIPTION
This should resolve issue #5; verify the lookahead for the 'P' specifier is reasonable.